### PR TITLE
feat: track bingo status and hide badge names

### DIFF
--- a/src/Bingo.js
+++ b/src/Bingo.js
@@ -55,21 +55,36 @@ export default function Bingo() {
     if (match) checkPatterns(next);
   };
 
+  const hasHorizontal = logged.row1 || logged.row2;
+  const hasVertical = logged.col1 || logged.col2;
+  const hasDiagonal = logged.diag1 || logged.diag2;
+  const hasFull = logged.full;
+
   return (
     <div className="p-4">
+      <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <label className="mr-2">Kies je student:</label>
+          <select
+            value={activeStudent}
+            onChange={(e) => resetState(e.target.value)}
+            className="border p-1"
+          >
+            {studentIds.map((id) => (
+              <option key={id} value={id}>
+                {studentAnswers[id].name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <a href="#/student" className="px-4 py-2 border rounded self-start">Terug naar puntenoverzicht</a>
+      </div>
+
       <div className="mb-4">
-        <label className="mr-2">Kies je student:</label>
-        <select
-          value={activeStudent}
-          onChange={(e) => resetState(e.target.value)}
-          className="border p-1"
-        >
-          {studentIds.map((id) => (
-            <option key={id} value={id}>
-              {studentAnswers[id].name}
-            </option>
-          ))}
-        </select>
+        <div>Horizontale bingo: {hasHorizontal ? 'ja' : 'nee'}</div>
+        <div>Verticale bingo: {hasVertical ? 'ja' : 'nee'}</div>
+        <div>Diagonale bingo: {hasDiagonal ? 'ja' : 'nee'}</div>
+        <div>Volle kaart: {hasFull ? 'ja' : 'nee'}</div>
       </div>
       <div className="grid grid-cols-2 gap-4">
         {['Q1', 'Q2', 'Q3', 'Q4'].map((q) => {

--- a/src/Student.js
+++ b/src/Student.js
@@ -391,15 +391,25 @@ export default function Student({
             <Card title="Jouw recente activiteiten" className="lg:col-span-2 max-h-[320px] overflow-auto">
               <ul className="space-y-2 text-sm">
                 {myAwards.length === 0 && <li>Geen recente items.</li>}
-                {myAwards.map((a) => (
-                  <li key={a.id} className="flex justify-between gap-2">
-                    <span>
-                      {new Date(a.ts).toLocaleString()} · {a.type === 'student' ? 'Individueel' : `Groep (${myGroup?.name || '-'})`}{' '}
-                      {a.reason ? `— ${a.reason}` : ''}
-                    </span>
-                    <span className={`font-semibold ${a.amount >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>{a.amount >= 0 ? '+' : ''}{a.amount}</span>
-                  </li>
-                ))}
+                {myAwards.map((a) => {
+                  const isBadge = a.reason?.startsWith('Badge');
+                  return (
+                    <li key={a.id} className="flex justify-between gap-2">
+                      <span>
+                        {new Date(a.ts).toLocaleString()} · {isBadge
+                          ? 'Badges toegekend'
+                          : a.type === 'student'
+                          ? 'Individueel'
+                          : `Groep (${myGroup?.name || '-'})`}{' '}
+                        {!isBadge && a.reason ? `— ${a.reason}` : ''}
+                      </span>
+                      <span className={`font-semibold ${a.amount >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>
+                        {a.amount >= 0 ? '+' : ''}
+                        {a.amount}
+                      </span>
+                    </li>
+                  );
+                })}
               </ul>
             </Card>
 


### PR DESCRIPTION
## Summary
- show generic message instead of badge names in students' recent activity
- add link back to points overview on bingo page
- display bingo progress (horizontal, vertical, diagonal, full card) at top of bingo page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af3ef63ff4832e88d38e506fc6328e