### PR TITLE
Allow bingo import with fewer answers

### DIFF
--- a/scripts/importBingoCsv.js
+++ b/scripts/importBingoCsv.js
@@ -94,11 +94,8 @@ function main() {
     for (const q of ['Q1', 'Q2', 'Q3', 'Q4']) {
       const idx = qIdx[q];
       const raw = idx >= 0 ? cols[idx] || '' : '';
-      const arr = splitAnswers(raw);
-      if (arr.length < 3) {
-        console.error(`${email}: minder dan 3 antwoorden voor ${q}`);
-        return;
-      }
+      const arr = splitAnswers(raw).slice(0, 3);
+      while (arr.length < 3) arr.push('');
       answers[q] = arr;
     }
 

--- a/src/Bingo.js
+++ b/src/Bingo.js
@@ -131,8 +131,8 @@ export default function Bingo({ selectedStudentId }) {
                 <div>
                   <div className="font-semibold mb-1">{questions[q]}</div>
                   <ul className="list-disc ml-4 mb-2">
-                    {studentAnswers[activeStudent][q].map((a) => (
-                      <li key={a}>{a}</li>
+                    {studentAnswers[activeStudent][q].map((a, i) => (
+                      <li key={i}>{a}</li>
                     ))}
                   </ul>
                   <select


### PR DESCRIPTION
## Summary
- Accept students who provide fewer than three answers per question when importing bingo CSV, padding missing slots with blanks
- Avoid React key warnings by indexing bingo answers in the bingo view

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af59d309bc832eadce08fa32e254db