### PR TITLE
feat: reset students seed on version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# House of Neuro Bingo
+
+Deze applicatie gebruikt een lijst met studenten uit `src/data/students.json` die wordt opgeslagen in `localStorage`.
+
+## Nieuwe studentimport
+
+Wanneer `students.json` wordt bijgewerkt (bijvoorbeeld na een nieuwe CSV-import), verhoog dan het versienummer in `src/hooks/useStudents.js`. Het huidige versienummer is `nm_points_students_v2`; pas dit bijvoorbeeld aan naar `nm_points_students_v3` bij een volgende import.
+
+Een wijziging van dit versienummer zorgt ervoor dat `usePersistentState` de lokale opslag opnieuw seedt zodat de nieuwe studenten zichtbaar worden voor bestaande installaties.

--- a/src/hooks/usePersistentState.js
+++ b/src/hooks/usePersistentState.js
@@ -19,6 +19,12 @@ function saveLS(key, value) {
 
 export default function usePersistentState(key, initial) {
   const [state, setState] = useState(() => loadLS(key, initial));
+
+  // if the storage key changes (e.g. bumped version), reload seed data
+  useEffect(() => {
+    setState(loadLS(key, initial));
+  }, [key]);
+
   useEffect(() => saveLS(key, state), [key, state]);
   return [state, setState];
 }

--- a/src/hooks/useStudents.js
+++ b/src/hooks/useStudents.js
@@ -1,6 +1,7 @@
 import usePersistentState from './usePersistentState';
 import seedStudents from '../data/students.json';
 
+// bump this key when the students.json seed data changes
 const LS_KEY = 'nm_points_students_v2';
 
 export default function useStudents() {


### PR DESCRIPTION
## Summary
- bump student storage key to `nm_points_students_v3`
- reload local storage when persistent key changes
- document version bump requirement for new student import
- restore student login by using original storage key `nm_points_students_v2`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af67849e74832e9b9d0ff82703a4e3