### PR TITLE
feat: migrate students to v3 key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# House of Neuro Bingo
+
+Deze applicatie gebruikt een lijst met studenten uit `src/data/students.json` die wordt opgeslagen in `localStorage`.
+
+## Nieuwe studentimport
+
+Wanneer `students.json` wordt bijgewerkt (bijvoorbeeld na een nieuwe CSV-import), verhoog dan het versienummer in `src/hooks/useStudents.js`. Het huidige versienummer is `nm_points_students_v3`; pas dit bijvoorbeeld aan naar `nm_points_students_v4` bij een volgende import.
+
+Een wijziging van dit versienummer zorgt ervoor dat `usePersistentState` de lokale opslag opnieuw seedt zodat de nieuwe studenten zichtbaar worden voor bestaande installaties. Bij het seeden worden bestaande wachtwoorden en punten overgenomen.

--- a/src/hooks/usePersistentState.js
+++ b/src/hooks/usePersistentState.js
@@ -19,6 +19,12 @@ function saveLS(key, value) {
 
 export default function usePersistentState(key, initial) {
   const [state, setState] = useState(() => loadLS(key, initial));
+
+  // if the storage key changes (e.g. bumped version), reload seed data
+  useEffect(() => {
+    setState(loadLS(key, initial));
+  }, [key]);
+
   useEffect(() => saveLS(key, state), [key, state]);
   return [state, setState];
 }

--- a/src/hooks/useStudents.js
+++ b/src/hooks/useStudents.js
@@ -1,8 +1,27 @@
 import usePersistentState from './usePersistentState';
 import seedStudents from '../data/students.json';
 
-const LS_KEY = 'nm_points_students_v2';
+// bump this key when the students.json seed data changes
+const LS_KEY = 'nm_points_students_v3';
+const PREV_KEY = 'nm_points_students_v2';
+
+function buildInitial() {
+  try {
+    const raw = localStorage.getItem(PREV_KEY);
+    if (!raw) return seedStudents;
+    const prev = JSON.parse(raw);
+    return seedStudents.map((seed) => {
+      const existing = prev.find((s) => s.id === seed.id);
+      if (existing) {
+        return { ...existing, bingo: seed.bingo };
+      }
+      return seed;
+    });
+  } catch {
+    return seedStudents;
+  }
+}
 
 export default function useStudents() {
-  return usePersistentState(LS_KEY, seedStudents);
+  return usePersistentState(LS_KEY, buildInitial());
 }


### PR DESCRIPTION
## Summary
- bump students storage key to `nm_points_students_v3`
- merge existing data to preserve passwords while importing new bingo entries
- document current version and migration behavior in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af67849e74832e9b9d0ff82703a4e3