### PR TITLE
feat: add csv import for students

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# House of Neuro Bingo
+
+Deze applicatie gebruikt een lijst met studenten uit `src/data/students.json` die wordt opgeslagen in `localStorage`.
+
+## Nieuwe studentimport
+
+Open de beheerderpagina en klik in **Studenten beheren** op **Importeer CSV-gegevens**. Kies het CSV-bestand met bingo-antwoorden; de gegevens worden samengevoegd met bestaande studenten zonder wachtwoorden of punten te verliezen.


### PR DESCRIPTION
## Summary
- keep existing login data by continuing to use `nm_points_students_v2`
- allow admins to upload a CSV that merges bingo answers into student records
- document the new import workflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af67849e74832e9b9d0ff82703a4e3