### PR TITLE
Clean up student state hooks

### DIFF
--- a/src/hooks/usePersistentState.js
+++ b/src/hooks/usePersistentState.js
@@ -21,16 +21,10 @@ export default function usePersistentState(key, initial) {
   const [state, setState] = useState(() => loadLS(key, initial));
 
 
-  // when the key changes, reload from storage or seed data
+  // when the key or initial value changes, reload from storage or seed data
   useEffect(() => {
     setState(loadLS(key, initial));
   }, [key, initial]);
-
-  // if the storage key changes (e.g. bumped version), reload seed data
-  useEffect(() => {
-    setState(loadLS(key, initial));
-  }, [key]);
-
 
   useEffect(() => saveLS(key, state), [key, state]);
 

--- a/src/hooks/useStudents.js
+++ b/src/hooks/useStudents.js
@@ -38,32 +38,4 @@ export default function useStudents() {
   }, [setStudents]);
 
   return [students, setStudents];
-
-// bump this key when the students.json seed data changes
-
-const LS_KEY = 'nm_points_students_v3';
-const PREV_KEY = 'nm_points_students_v2';
-
-function buildInitial() {
-  try {
-    const raw = localStorage.getItem(PREV_KEY);
-    if (!raw) return seedStudents;
-    const prev = JSON.parse(raw);
-    return seedStudents.map((seed) => {
-      const existing = prev.find((s) => s.id === seed.id);
-      if (existing) {
-        return { ...existing, bingo: seed.bingo };
-      }
-      return seed;
-    });
-  } catch {
-    return seedStudents;
-  }
-}
-
-
-
-export default function useStudents() {
-  return usePersistentState(LS_KEY, buildInitial());
-
 }


### PR DESCRIPTION
## Summary
- remove duplicate export and constants from `useStudents`
- simplify `usePersistentState` to avoid redundant reloads

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af7635342c832e918a2fc7a235642b