### PR TITLE
Allow admin preview of bingo card

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ export default function App() {
   const denyAdmin  = () => { try { localStorage.removeItem(ADMIN_LS); } catch {} setIsAdmin(false); };
 
   const [selectedStudentId, setSelectedStudentId] = usePersistentState('nm_points_current_student', '');
+  const [previewId] = usePersistentState('nm_preview_student', '');
 
   const logoutAdmin = () => {
     denyAdmin();
@@ -87,6 +88,8 @@ export default function App() {
         ) : route === '/bingo' ? (
           selectedStudentId ? (
             <Bingo selectedStudentId={selectedStudentId} />
+          ) : isAdmin && previewId ? (
+            <Bingo selectedStudentId={previewId} previewMode />
           ) : (
             <Auth
               onAdminLogin={() => {

--- a/src/Bingo.js
+++ b/src/Bingo.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { questions } from './bingoData';
 import useStudents from './hooks/useStudents';
 
-export default function Bingo({ selectedStudentId }) {
+export default function Bingo({ selectedStudentId, previewMode = false }) {
   const [students] = useStudents();
 
   const studentAnswers = useMemo(() => {
@@ -106,7 +106,12 @@ export default function Bingo({ selectedStudentId }) {
 
       <div className="mb-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="font-semibold">{studentAnswers[activeStudent].name}</div>
-        <a href="#/student" className="px-4 py-2 border rounded self-start">Terug naar puntenoverzicht</a>
+        <a
+          href={previewMode ? '#/admin/preview' : '#/student'}
+          className="px-4 py-2 border rounded self-start"
+        >
+          Terug naar puntenoverzicht
+        </a>
       </div>
 
       <div className="mb-4">


### PR DESCRIPTION
## Summary
- allow admins to open bingo card from student preview
- show return link back to admin preview when previewing bingo

## Testing
- `npm test` (fails: missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68afec967c1c832e9a660a7c6562e10b