### PR TITLE
feat: sync students with server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@ Deze applicatie gebruikt een lijst met studentenaccounts uit `src/data/students.
 Standaard is dit bestand leeg: studenten maken zelf een account aan in de app en
 deze gegevens worden lokaal opgeslagen in `localStorage`.
 
+Bij het opstarten haalt de app de actuele studentenlijst op uit `/data/students.json`
+en vult hiermee `localStorage`. Wanneer de lijst met studenten wijzigt, stuurt de
+hook `useStudents` de complete array naar de endpoint `/api/students`. Het script
+`scripts/studentsApi.js` luistert op deze endpoint en overschrijft `src/data/students.json`
+met de ontvangen gegevens.
+
+Start de API tijdens ontwikkeling met:
+
+```
+node scripts/studentsApi.js
+```
+
 Het script `scripts/importBingoCsv.js` leest een CSV-bestand met antwoorden voor
 de bingokaart en koppelt deze aan bestaande studentaccounts op basis van het
 e-mailadres. Elke e-mail in de CSV moet overeenkomen met een account in

--- a/scripts/studentsApi.js
+++ b/scripts/studentsApi.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const studentsPath = path.join(__dirname, '../src/data/students.json');
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/api/students') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const data = JSON.parse(body || '[]');
+        fs.writeFile(studentsPath, JSON.stringify(data, null, 2) + '\n', (err) => {
+          if (err) {
+            res.writeHead(500);
+            res.end('Failed to write file');
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok' }));
+        });
+      } catch {
+        res.writeHead(400);
+        res.end('Invalid JSON');
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end('Not found');
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`Student API listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- fetch students.json on startup to seed localStorage
- post student list changes to /api/students
- add Node API script that overwrites src/data/students.json
- document workflow in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68affc6f3f64832ea7ebac413c814ce9