### PR TITLE
Configure students API base URL and proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "react-scripts build",
     "start": "react-scripts start"
   },
+  "proxy": "http://localhost:3001",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/hooks/useStudents.js
+++ b/src/hooks/useStudents.js
@@ -3,6 +3,7 @@ import usePersistentState from './usePersistentState';
 
 const VERSION = 3;
 const LS_KEY = `nm_points_students_v${VERSION}`;
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || 'http://localhost:3001';
 
 export default function useStudents() {
   const [students, setStudentsBase] = usePersistentState(LS_KEY, []);
@@ -57,7 +58,7 @@ export default function useStudents() {
 
       setStudentsBase((prev) => {
         const next = typeof value === 'function' ? value(prev) : value;
-        fetch('/api/students', {
+        fetch(`${API_BASE_URL}/api/students`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(next),


### PR DESCRIPTION
## Summary
- Allow students API to point to a configurable base URL defaulting to `http://localhost:3001`
- Proxy `/api` requests to `http://localhost:3001` via CRA dev server

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b016e7e4a0832ea28663964fc602d6