### PR TITLE
fix: proxy-friendly student API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Bij het opstarten haalt de app de actuele studentenlijst op uit `/data/students.
 en vult hiermee `localStorage`. Wanneer de lijst met studenten wijzigt, stuurt de
 hook `useStudents` de complete array naar de endpoint `/api/students`. Het script
 `scripts/studentsApi.js` luistert op deze endpoint en overschrijft `src/data/students.json`
-met de ontvangen gegevens.
+met de ontvangen gegevens. Tijdens ontwikkeling draait deze API standaard op
+`http://localhost:3001`; de React devserver stuurt `/api`-aanroepen hierheen door.
+Voor een andere URL kan `REACT_APP_API_BASE_URL` worden ingesteld.
 
 Start de API tijdens ontwikkeling met:
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "react-scripts build",
     "start": "react-scripts start"
   },
+  "proxy": "http://localhost:3001",
   "browserslist": {
     "production": [
       ">0.2%",

--- a/src/hooks/useStudents.js
+++ b/src/hooks/useStudents.js
@@ -3,6 +3,10 @@ import usePersistentState from './usePersistentState';
 
 const VERSION = 3;
 const LS_KEY = `nm_points_students_v${VERSION}`;
+// Base URL for the student API. Leave empty to use the same origin, which allows
+// the Create React App development server to proxy requests to the API server
+// without triggering CORS errors.
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '';
 
 export default function useStudents() {
   const [students, setStudentsBase] = usePersistentState(LS_KEY, []);
@@ -57,7 +61,7 @@ export default function useStudents() {
 
       setStudentsBase((prev) => {
         const next = typeof value === 'function' ? value(prev) : value;
-        fetch('/api/students', {
+        fetch(`${API_BASE_URL}/api/students`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(next),


### PR DESCRIPTION
## Summary
- avoid CORS by defaulting student API base URL to same origin
- document API base and proxy behaviour in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b016e7e4a0832ea28663964fc602d6