### PR TITLE
Ensure teacher and student accounts persist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # House of Neuro Bingo
 
-Deze applicatie gebruikt een lijst met studentenaccounts uit `src/data/students.json`.
-Standaard is dit bestand leeg: studenten maken zelf een account aan in de app en
-deze gegevens worden lokaal opgeslagen in `localStorage`.
+Deze applicatie gebruikt lijsten met studenten- en docentenaccounts uit
+`src/data/students.json` en `src/data/teachers.json`. Standaard zijn deze
+bestanden leeg: gebruikers maken zelf een account aan in de app en deze
+gegevens worden lokaal opgeslagen in `localStorage`.
 
-Bij het opstarten haalt de app de actuele studentenlijst op uit `/data/students.json`
-en vult hiermee `localStorage`. Wanneer de lijst met studenten wijzigt, stuurt de
-hook `useStudents` de complete array naar de endpoint `/api/students`. Het script
-`scripts/studentsApi.js` luistert op deze endpoint en overschrijft `src/data/students.json`
-met de ontvangen gegevens. Tijdens ontwikkeling draait deze API standaard op
-`http://localhost:3001`; de React devserver stuurt `/api`-aanroepen hierheen door.
-Voor een andere URL kan `REACT_APP_API_BASE_URL` worden ingesteld.
+Bij het opstarten haalt de app de actuele lijsten op uit `/data/students.json`
+en `/data/teachers.json` en vult hiermee `localStorage`. Wanneer de lijsten
+wijzigen, sturen de hooks `useStudents` en `useTeachers` de complete arrays naar
+de endpoints `/api/students` en `/api/teachers`. Het script
+`scripts/studentsApi.js` luistert op deze endpoints en overschrijft de bestanden
+`src/data/students.json` en `src/data/teachers.json` met de ontvangen gegevens.
+Tijdens ontwikkeling draait deze API standaard op `http://localhost:3001`; de
+React devserver stuurt `/api`-aanroepen hierheen door. Voor een andere URL kan
+`REACT_APP_API_BASE_URL` worden ingesteld.
 
 Start de API tijdens ontwikkeling met:
 

--- a/scripts/studentsApi.js
+++ b/scripts/studentsApi.js
@@ -4,30 +4,37 @@ const fs = require('fs');
 const path = require('path');
 
 const studentsPath = path.join(__dirname, '../src/data/students.json');
+const teachersPath = path.join(__dirname, '../src/data/teachers.json');
+
+function handleWrite(req, res, targetPath) {
+  let body = '';
+  req.on('data', (chunk) => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    try {
+      const data = JSON.parse(body || '[]');
+      fs.writeFile(targetPath, JSON.stringify(data, null, 2) + '\n', (err) => {
+        if (err) {
+          res.writeHead(500);
+          res.end('Failed to write file');
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+      });
+    } catch {
+      res.writeHead(400);
+      res.end('Invalid JSON');
+    }
+  });
+}
 
 const server = http.createServer((req, res) => {
   if (req.method === 'POST' && req.url === '/api/students') {
-    let body = '';
-    req.on('data', chunk => {
-      body += chunk;
-    });
-    req.on('end', () => {
-      try {
-        const data = JSON.parse(body || '[]');
-        fs.writeFile(studentsPath, JSON.stringify(data, null, 2) + '\n', (err) => {
-          if (err) {
-            res.writeHead(500);
-            res.end('Failed to write file');
-            return;
-          }
-          res.writeHead(200, { 'Content-Type': 'application/json' });
-          res.end(JSON.stringify({ status: 'ok' }));
-        });
-      } catch {
-        res.writeHead(400);
-        res.end('Invalid JSON');
-      }
-    });
+    handleWrite(req, res, studentsPath);
+  } else if (req.method === 'POST' && req.url === '/api/teachers') {
+    handleWrite(req, res, teachersPath);
   } else {
     res.writeHead(404);
     res.end('Not found');
@@ -36,5 +43,5 @@ const server = http.createServer((req, res) => {
 
 const PORT = process.env.PORT || 3001;
 server.listen(PORT, () => {
-  console.log(`Student API listening on port ${PORT}`);
+  console.log(`Data API listening on port ${PORT}`);
 });

--- a/src/hooks/useTeachers.js
+++ b/src/hooks/useTeachers.js
@@ -1,8 +1,40 @@
+import { useEffect, useCallback } from 'react';
 import usePersistentState from './usePersistentState';
-import seedTeachers from '../data/teachers.json';
 
 const LS_KEY = 'nm_points_teachers_v1';
+const API_BASE_URL = process.env.REACT_APP_API_BASE_URL || '';
 
 export default function useTeachers() {
-  return usePersistentState(LS_KEY, seedTeachers);
+  const [teachers, setTeachersBase] = usePersistentState(LS_KEY, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/data/teachers.json')
+      .then((r) => r.json())
+      .then((seedTeachers) => {
+        if (cancelled) return;
+        setTeachersBase((curr) => (curr.length ? curr : seedTeachers));
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [setTeachersBase]);
+
+  const setTeachers = useCallback(
+    (value) => {
+      setTeachersBase((prev) => {
+        const next = typeof value === 'function' ? value(prev) : value;
+        fetch(`${API_BASE_URL}/api/teachers`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(next),
+        }).catch(() => {});
+        return next;
+      });
+    },
+    [setTeachersBase]
+  );
+
+  return [teachers, setTeachers];
 }


### PR DESCRIPTION
## Summary
- Persist teacher accounts by posting to `/api/teachers` and loading from `/data/teachers.json`
- Expand data API to handle both student and teacher JSON files
- Document teacher data flow alongside students

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b01bdf944c832eb5d854da7fdf75ad