### PR TITLE
Sync student and teacher data with server

### DIFF
--- a/src/hooks/useStudents.js
+++ b/src/hooks/useStudents.js
@@ -43,6 +43,18 @@ export default function useStudents() {
     setStudentsState(newStudents);
     localStorage.setItem('nm_points_students_v3', JSON.stringify(newStudents));
     window.studentsData = newStudents;
+    const baseUrl = process.env.REACT_APP_API_BASE_URL || '';
+    try {
+      fetch(`${baseUrl}/api/students`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newStudents)
+      }).catch(err => {
+        console.error('Failed to sync students:', err);
+      });
+    } catch (e) {
+      console.error('Failed to sync students:', e);
+    }
   };
 
   return [students, setStudents];

--- a/src/hooks/useTeachers.js
+++ b/src/hooks/useTeachers.js
@@ -35,6 +35,18 @@ export default function useTeachers() {
     const newTeachers = typeof updater === 'function' ? updater(teachers) : updater;
     setTeachersState(newTeachers);
     localStorage.setItem('nm_points_teachers_v3', JSON.stringify(newTeachers));
+    const baseUrl = process.env.REACT_APP_API_BASE_URL || '';
+    try {
+      fetch(`${baseUrl}/api/teachers`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(newTeachers)
+      }).catch(err => {
+        console.error('Failed to sync teachers:', err);
+      });
+    } catch (e) {
+      console.error('Failed to sync teachers:', e);
+    }
   };
 
   return [teachers, setTeachers];


### PR DESCRIPTION
## Summary
- Sync updated student lists to server API for shared persistence
- Sync teacher data updates to backend API

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b186f6deb8832eaf8f81106d857f92